### PR TITLE
[UPLOAD-233] Copy data into V8 memory cage instead

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -592,7 +592,8 @@ static napi_value get_aligned_buffer(napi_env env, napi_callback_info info) {
   assert(((uintptr_t)(const void *)(ptr) & (alignment - 1)) == 0);
   memset(ptr, 0, size);
   napi_value buffer;
-  OK(napi_create_external_buffer(env, size, ptr, free_aligned, NULL, &buffer));
+  void* copied_data = NULL;
+  OK(napi_create_buffer_copy(env, size, ptr, &copied_data, &buffer));
   return buffer;
 }
 


### PR DESCRIPTION
[Since Electron v21](https://www.electronjs.org/docs/latest/breaking-changes#behavior-changed-v8-memory-cage-enabled) there is a V8 memory cage/sandbox that has been enabled, which prevents native modules from pointing to external memory.

The fix is to copy externally-created buffers into the V8 memory cage before passing them to JavaScript:
https://www.electronjs.org/blog/v8-memory-cage#i-want-to-refactor-a-node-native-module-to-support-electron-21-how-do-i-do-that

Without this fix the Electron render process crashes when getAlignedBuffer() is called. I've tested that this fix works on Windows 11 and MacOS Ventura.